### PR TITLE
Add MeshManager skeleton and ticket updates

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -3,7 +3,7 @@
 The system uses ESP32 boards arranged in a mesh network to drive LED fixtures. Nodes elect a root that bridges to Art-Net or DMX sources. A web-based console provides configuration and playback controls.
 
 ## Components
-- **MeshManager**: Maintains ESP-Mesh connections and handles message routing.
+ - **MeshManager**: Initializes ESP-Mesh, handles root election, LED status, and message routing.
 - **SettingsManager**: Persists configuration using NVS.
 - **WiFiManager**: Connects to configured network or starts an access point.
 - **WebServer**: Provides REST API and serves the web console.

--- a/docs/tickets.md
+++ b/docs/tickets.md
@@ -87,3 +87,85 @@ Setup AsyncWebServer and REST API:
 - [x] Code Written
 - [x] Tests Passed
 - [x] Documentation Written
+
+---
+
+## 🎟️ Ticket T2.1: ESP-Mesh Init
+
+**Milestone**: Mesh Networking Framework
+**Created by**: system
+**Status**: 🚧 In Progress
+**Priority**: High
+
+### 🎯 Description
+Set up the ESP-Mesh network layer so nodes can join a mesh.
+Use the ESP-IDF mesh APIs. Prepare a MeshManager class with a `begin()` method.
+
+### ✅ Checklist
+- [ ] Started
+- [ ] Tests Written
+- [ ] Code Written
+- [ ] Tests Passed
+- [ ] Documentation Written
+
+---
+
+## 🎟️ Ticket T2.2: Root Node Auto-Election
+
+**Milestone**: Mesh Networking Framework
+**Created by**: system
+**Status**: 🚧 In Progress
+**Priority**: High
+
+### 🎯 Description
+Implement logic so that one node in the mesh becomes the root automatically.
+Expose `is_root_node()` in `MeshManager`.
+
+### ✅ Checklist
+- [ ] Started
+- [ ] Tests Written
+- [ ] Code Written
+- [ ] Tests Passed
+- [ ] Documentation Written
+
+---
+
+## 🎟️ Ticket T2.3: Mesh Messaging
+
+**Milestone**: Mesh Networking Framework
+**Created by**: system
+**Status**: 🚧 In Progress
+**Priority**: Medium
+
+### 🎯 Description
+Provide broadcast messaging between nodes.
+Add `send_message()` and `on_message()` handlers in `MeshManager`.
+
+### ✅ Checklist
+- [ ] Started
+- [ ] Tests Written
+- [ ] Code Written
+- [ ] Tests Passed
+- [ ] Documentation Written
+
+---
+
+## 🎟️ Ticket T2.4: LED Feedback for Mesh State
+
+**Milestone**: Mesh Networking Framework
+**Created by**: system
+**Status**: 🚧 In Progress
+**Priority**: Low
+
+### 🎯 Description
+Use the onboard LED to indicate mesh status:
+- Fast blink when searching
+- Solid when connected as root
+- Slow blink when connected as a node
+
+### ✅ Checklist
+- [ ] Started
+- [ ] Tests Written
+- [ ] Code Written
+- [ ] Tests Passed
+- [ ] Documentation Written

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,10 +2,12 @@
 #include "settings_manager.h"
 #include "wifi_manager.h"
 #include "web_server.h"
+#include "mesh_manager.h"
 
 SettingsManager settings_mgr;
 WiFiManager wifi_mgr;
 WebServer web_server;
+MeshManager mesh_mgr;
 ControllerSettings settings;
 
 void setup() {
@@ -15,9 +17,11 @@ void setup() {
     if (!wifi_mgr.connect(settings)) {
         wifi_mgr.start_ap();
     }
+    mesh_mgr.begin(settings.is_root);
     web_server.begin(settings_mgr, settings);
 }
 
 void loop() {
-    delay(1000);
+    mesh_mgr.update();
+    delay(10);
 }

--- a/src/mesh_manager.cpp
+++ b/src/mesh_manager.cpp
@@ -1,0 +1,35 @@
+#include "mesh_manager.h"
+#include <esp_wifi.h>
+#include <esp_mesh.h>
+
+bool MeshManager::begin(bool is_root) {
+    root = is_root;
+    pinMode(LED_BUILTIN, OUTPUT);
+    // TODO: Initialize ESP-Mesh here
+    return true;
+}
+
+void MeshManager::update() {
+    // TODO: Handle mesh events
+    unsigned long interval = root ? 1000 : 300;
+    if (millis() - last_led_toggle > interval) {
+        last_led_toggle = millis();
+        led_state = !led_state;
+        digitalWrite(LED_BUILTIN, led_state);
+    }
+}
+
+bool MeshManager::is_root_node() const {
+    return root;
+}
+
+void MeshManager::send_message(const String &msg) {
+    // TODO: Broadcast message via mesh
+    if (message_cb) {
+        message_cb(msg); // loopback for now
+    }
+}
+
+void MeshManager::on_message(std::function<void(const String&)> cb) {
+    message_cb = cb;
+}

--- a/src/mesh_manager.h
+++ b/src/mesh_manager.h
@@ -1,0 +1,21 @@
+#ifndef MESH_MANAGER_H
+#define MESH_MANAGER_H
+
+#include <Arduino.h>
+#include <functional>
+
+class MeshManager {
+public:
+    bool begin(bool is_root);
+    void update();
+    bool is_root_node() const;
+    void send_message(const String &msg);
+    void on_message(std::function<void(const String&)> cb);
+private:
+    bool root = false;
+    std::function<void(const String&)> message_cb = nullptr;
+    unsigned long last_led_toggle = 0;
+    bool led_state = false;
+};
+
+#endif // MESH_MANAGER_H


### PR DESCRIPTION
## Summary
- sketch out MeshManager class for upcoming mesh features
- wire MeshManager into main firmware
- document MeshManager role in design doc
- create tickets T2.1–T2.4 for Mesh Networking Framework

## Testing
- `pio run` *(fails: Platform Manager installing blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68740a951d248332aeeae6529cadbf88