### PR TITLE
Add Arduino CLI build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ A firmware project for ESP32 devices that controls a network of LED nodes. It im
 3. Upload the web console with `pio run --target uploadfs`.
 4. Flash the firmware with `pio run --target upload`.
 
+### Arduino CLI
+An optional helper script is provided for those using the Arduino IDE or
+`arduino-cli`. Execute `scripts/arduino_cli.sh` and pass your serial port to
+verify, build and upload the firmware:
+
+```bash
+./scripts/arduino_cli.sh /dev/ttyUSB0
+```
+The script will install the ESP32 core if needed and then compile and upload.
+
 ## Folder Structure
 ```
 /src  - firmware source

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -55,3 +55,7 @@ This file defines major milestones and high-level tasks for the LED Mesh Control
 
 - T7.1: Project Wiki and README
 
+## ✅ Milestone 8: Build Tools
+
+- T8.1: Arduino CLI Script
+

--- a/docs/tickets.md
+++ b/docs/tickets.md
@@ -467,3 +467,22 @@ Document all firmware functionality in a wiki-style markdown file and update the
 - [x] Code Written
 - [x] Tests Passed
 - [x] Documentation Written
+
+---
+
+## 🎟️ Ticket T8.1: Arduino CLI Script
+
+**Milestone**: Build Tools
+**Created by**: assistant
+**Status**: 🚧 In Progress
+**Priority**: Low
+
+### 🎯 Description
+Provide a shell script using `arduino-cli` to verify, build and upload the firmware to an ESP32 dev board.
+
+### ✅ Checklist
+- [ ] Started
+- [ ] Tests Written
+- [ ] Code Written
+- [ ] Tests Passed
+- [ ] Documentation Written

--- a/scripts/arduino_cli.sh
+++ b/scripts/arduino_cli.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Simple helper script to verify, compile and upload using arduino-cli
+
+BOARD_FQBN="esp32:esp32:esp32"    # FQBN for ESP32 Dev Module
+PORT=${1:-/dev/ttyUSB0}            # Serial port, override with first arg
+
+PROJECT_DIR="$(dirname "$0")/.."
+
+# Ensure board platform is installed
+arduino-cli core update-index
+arduino-cli core install esp32:esp32
+
+# Verify/build the sketch
+arduino-cli compile --fqbn "$BOARD_FQBN" "$PROJECT_DIR"
+
+# Upload if compile succeeds
+arduino-cli upload -p "$PORT" --fqbn "$BOARD_FQBN" "$PROJECT_DIR"


### PR DESCRIPTION
## Summary
- add a helper script `scripts/arduino_cli.sh`
- document script usage in README
- add new "Build Tools" milestone with ticket T8.1

## Testing
- `platformio run`

------
https://chatgpt.com/codex/tasks/task_e_6874e0d3c1c08332bc64ce931a8f1e55