### PR TITLE
Fix PlatformIO build failure

### DIFF
--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -4,12 +4,14 @@
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 OUTPUT_DIR="$ROOT_DIR/images"
 
-# Ensure PlatformIO is installed
-if ! command -v platformio >/dev/null 2>&1; then
+# Ensure PlatformIO is installed and up to date
+if command -v platformio >/dev/null 2>&1; then
+  echo "Updating PlatformIO..."
+else
   echo "Installing PlatformIO..."
-  python3 -m pip install --user platformio
-  export PATH="$HOME/.local/bin:$PATH"
 fi
+python3 -m pip install --user -U platformio
+export PATH="$HOME/.local/bin:$PATH"
 
 cd "$ROOT_DIR"
 platformio run


### PR DESCRIPTION
## Summary
- ensure `build_image.sh` installs/upgrades PlatformIO

## Testing
- `./scripts/build_image.sh`

------
https://chatgpt.com/codex/tasks/task_e_6874fdde6e1c8332946cd686ea6b60dc