### PR TITLE
Add combined binary build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ A firmware project for ESP32 devices that controls a network of LED nodes. It im
 
 ### Build Script
 The `scripts/build_image.sh` helper installs PlatformIO (if missing) and
-generates firmware binaries. Run it from the project root:
+generates firmware binaries. It also builds the SPIFFS image and merges all
+artifacts into `combined.bin`. Run it from the project root:
 
 ```bash
 chmod +x scripts/build_image.sh
@@ -56,8 +57,9 @@ script to Unix line endings with `dos2unix scripts/build_image.sh` and rerun the
 command. The resulting files appear in the `images/` directory.
 
 ### Flashing Prebuilt Images
-The build script places three `.bin` files in the `images/` directory. To flash
-these images directly without using PlatformIO:
+The build script places the individual firmware bins and `spiffs.bin` in the
+`images/` directory. It also creates `combined.bin` which contains everything.
+To flash the separate files without using PlatformIO:
 
 1. Install [esptool.py](https://github.com/espressif/esptool) with `pip install esptool`.
 2. Put the ESP32 into bootloader mode (usually by holding the **BOOT** button
@@ -68,9 +70,17 @@ these images directly without using PlatformIO:
 esptool.py --chip esp32 --port /dev/ttyUSB0 --baud 921600 write_flash -z \
   0x1000 bootloader.bin \
   0x8000 partitions.bin \
-  0x10000 firmware.bin
+  0x10000 firmware.bin \
+  0x290000 spiffs.bin  # use the offset listed for the spiffs partition
 ```
 After flashing completes, reset the board to start the new firmware.
+
+To flash `combined.bin` in one step, run:
+
+```bash
+esptool.py --chip esp32 --port /dev/ttyUSB0 --baud 921600 write_flash \
+  0x0 combined.bin
+```
 
 ### Arduino CLI
 An optional helper script is provided for those using the Arduino IDE or

--- a/docs/tickets.md
+++ b/docs/tickets.md
@@ -706,3 +706,23 @@ Allow the HTTP server to start even when SPIFFS fails to mount and return the st
 - [x] Code Written
 - [x] Tests Passed
 - [ ] Documentation Written
+
+---
+
+## 🎟️ Ticket T8.11: Combined Firmware Image
+
+**Milestone**: Build Tools
+**Created by**: assistant
+**Status**: 🚧 In Progress
+**Priority**: Low
+
+### 🎯 Description
+Extend `build_image.sh` to generate `spiffs.bin` and merge all binaries into
+`combined.bin`. Document how to flash the single file.
+
+### ✅ Checklist
+- [ ] Started
+- [ ] Tests Written
+- [ ] Code Written
+- [ ] Tests Passed
+- [ ] Documentation Written

--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -30,14 +30,28 @@ if [ ! -f "$VENV_DIR/bin/activate" ]; then
 fi
 source "$VENV_DIR/bin/activate"
 pip install --upgrade pip > /dev/null
-pip install --upgrade platformio > /dev/null
+pip install --upgrade platformio esptool > /dev/null
 
 cd "$ROOT_DIR"
 platformio run
+platformio run --target buildfs
 
 mkdir -p "$OUTPUT_DIR"
 cp .pio/build/esp32dev/firmware.bin "$OUTPUT_DIR/" 2>/dev/null || true
 cp .pio/build/esp32dev/bootloader.bin "$OUTPUT_DIR/" 2>/dev/null || true
 cp .pio/build/esp32dev/partitions.bin "$OUTPUT_DIR/" 2>/dev/null || true
+cp .pio/build/esp32dev/spiffs.bin "$OUTPUT_DIR/" 2>/dev/null || true
+
+# Determine SPIFFS offset from the generated partition table
+SPIFFS_OFFSET=$(awk -F',' '/spiffs/ {gsub(/^[ \t]+|\r/, "", $4); print $4}' .pio/build/esp32dev/partitions.csv)
+
+# Create a single merged binary containing firmware and filesystem
+if [ -n "$SPIFFS_OFFSET" ]; then
+  esptool.py --chip esp32 merge_bin -o "$OUTPUT_DIR/combined.bin" \
+    0x1000 "$OUTPUT_DIR/bootloader.bin" \
+    0x8000 "$OUTPUT_DIR/partitions.bin" \
+    0x10000 "$OUTPUT_DIR/firmware.bin" \
+    "$SPIFFS_OFFSET" "$OUTPUT_DIR/spiffs.bin" > /dev/null
+fi
 
 echo "Firmware images stored in $OUTPUT_DIR"


### PR DESCRIPTION
## Summary
- generate spiffs.bin and merge bootloader, partitions, firmware and SPIFFS into one `combined.bin`
- document how to flash the merged image
- track work in new ticket T8.11

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit`
- `pip install esptool` *(fails: network access)*

------
https://chatgpt.com/codex/tasks/task_e_68752933969083328960f9d989b434d5