### PR TITLE
Add restartable WiFi credential workflow

### DIFF
--- a/LED_Mesh_Controller_Planning.ino
+++ b/LED_Mesh_Controller_Planning.ino
@@ -32,7 +32,11 @@ void setup() {
     Serial.begin(115200);
     settings_mgr.begin();
     settings_mgr.load(settings);
-    if (!wifi_mgr.connect(settings)) {
+    bool connected = false;
+    if (settings.extend_network) {
+        connected = wifi_mgr.connect(settings, 5);
+    }
+    if (!connected) {
         wifi_mgr.start_ap();
     }
     scene_mgr.begin();

--- a/data/app.js
+++ b/data/app.js
@@ -8,8 +8,11 @@ var startChannel = document.getElementById('start-channel');
 var ledCount = document.getElementById('led-count');
 var dmxUniverse = document.getElementById('dmx-universe');
 var isRoot = document.getElementById('is-root');
+var extendNetwork = document.getElementById('extend-network');
+var wifiDiv = document.getElementById('wifi-credentials');
 var ssid = document.getElementById('ssid');
 var password = document.getElementById('password');
+var restartBtn = document.getElementById('restart-btn');
 function loadSettings() {
     fetch('/settings').then(function (r) { return r.json(); }).then(function (s) {
         universe.value = String(s.universe);
@@ -17,8 +20,10 @@ function loadSettings() {
         ledCount.value = String(s.led_count);
         dmxUniverse.value = String(s.dmx_universe);
         isRoot.checked = s.is_root;
+        extendNetwork.checked = s.extend_network;
         ssid.value = s.ssid;
         password.value = s.password;
+        toggleWifi();
     });
 }
 function saveSettings() {
@@ -28,6 +33,7 @@ function saveSettings() {
         led_count: parseInt(ledCount.value, 10),
         dmx_universe: parseInt(dmxUniverse.value, 10),
         is_root: isRoot.checked,
+        extend_network: extendNetwork.checked,
         ssid: ssid.value,
         password: password.value
     };
@@ -66,6 +72,9 @@ function playScene(id) {
         body: JSON.stringify({ id: id })
     });
 }
+function toggleWifi() {
+    wifiDiv.style.display = extendNetwork.checked ? 'block' : 'none';
+}
 function loadNodes() {
     fetch('/nodes').then(function (r) { return r.json(); }).then(function (data) {
         nodeList.innerHTML = '';
@@ -80,5 +89,11 @@ function loadNodes() {
 (_b = document.getElementById('reload-btn')) === null || _b === void 0 ? void 0 : _b.addEventListener('click', loadScenes);
 (_c = document.getElementById('nodes-btn')) === null || _c === void 0 ? void 0 : _c.addEventListener('click', loadNodes);
 (_d = document.getElementById('save-settings-btn')) === null || _d === void 0 ? void 0 : _d.addEventListener('click', saveSettings);
+extendNetwork.addEventListener('change', toggleWifi);
+restartBtn.addEventListener('click', function () {
+    saveSettings();
+    fetch('/restart', { method: 'POST' });
+});
+toggleWifi();
 loadScenes();
 loadSettings();

--- a/data/app.ts
+++ b/data/app.ts
@@ -7,8 +7,11 @@ const startChannel = document.getElementById('start-channel') as HTMLInputElemen
 const ledCount = document.getElementById('led-count') as HTMLInputElement;
 const dmxUniverse = document.getElementById('dmx-universe') as HTMLInputElement;
 const isRoot = document.getElementById('is-root') as HTMLInputElement;
+const extendNetwork = document.getElementById('extend-network') as HTMLInputElement;
+const wifiDiv = document.getElementById('wifi-credentials') as HTMLDivElement;
 const ssid = document.getElementById('ssid') as HTMLInputElement;
 const password = document.getElementById('password') as HTMLInputElement;
+const restartBtn = document.getElementById('restart-btn') as HTMLButtonElement;
 
 interface Scene { id: number; name: string; effect: string; }
 interface Settings {
@@ -17,6 +20,7 @@ interface Settings {
   led_count: number;
   dmx_universe: number;
   is_root: boolean;
+  extend_network: boolean;
   ssid: string;
   password: string;
 }
@@ -28,8 +32,10 @@ function loadSettings() {
     ledCount.value = String(s.led_count);
     dmxUniverse.value = String(s.dmx_universe);
     isRoot.checked = s.is_root;
+    extendNetwork.checked = s.extend_network;
     ssid.value = s.ssid;
     password.value = s.password;
+    toggleWifi();
   });
 }
 
@@ -40,6 +46,7 @@ function saveSettings() {
     led_count: parseInt(ledCount.value, 10),
     dmx_universe: parseInt(dmxUniverse.value, 10),
     is_root: isRoot.checked,
+    extend_network: extendNetwork.checked,
     ssid: ssid.value,
     password: password.value
   };
@@ -82,6 +89,10 @@ function playScene(id: number) {
   });
 }
 
+function toggleWifi() {
+  wifiDiv.style.display = extendNetwork.checked ? 'block' : 'none';
+}
+
 function loadNodes() {
   fetch('/nodes').then(r => r.json()).then((data: string[]) => {
     nodeList.innerHTML = '';
@@ -97,6 +108,13 @@ document.getElementById('save-btn')?.addEventListener('click', saveScene);
 document.getElementById('reload-btn')?.addEventListener('click', loadScenes);
 document.getElementById('nodes-btn')?.addEventListener('click', loadNodes);
 document.getElementById('save-settings-btn')?.addEventListener('click', saveSettings);
+extendNetwork.addEventListener('change', toggleWifi);
+restartBtn.addEventListener('click', () => {
+  saveSettings();
+  fetch('/restart', { method: 'POST' });
+});
+
+toggleWifi();
 
 loadScenes();
 loadSettings();

--- a/data/index.html
+++ b/data/index.html
@@ -15,8 +15,12 @@
             <label>LED Count <input id="led-count" type="number" min="1"></label><br>
             <label>DMX Universe <input id="dmx-universe" type="number" min="1"></label><br>
             <label><input id="is-root" type="checkbox"> Root Node</label><br>
-            <input id="ssid" placeholder="WiFi SSID"><br>
-            <input id="password" type="password" placeholder="WiFi Password"><br>
+            <label><input id="extend-network" type="checkbox"> Extend Network</label><br>
+            <div id="wifi-credentials">
+                <input id="ssid" placeholder="WiFi SSID"><br>
+                <input id="password" type="password" placeholder="WiFi Password"><br>
+                <button id="restart-btn" class="button">Restart</button>
+            </div>
             <button id="save-settings-btn" class="button">Save Settings</button>
         </section>
         <section class="section scenes">

--- a/data/styles.css
+++ b/data/styles.css
@@ -44,3 +44,8 @@ h1 {
 .button:hover {
   background-color: #0056b3;
 }
+
+#wifi-credentials {
+  display: none;
+  margin-top: 8px;
+}

--- a/docs/tickets.md
+++ b/docs/tickets.md
@@ -726,3 +726,20 @@ Extend `build_image.sh` to generate `spiffs.bin` and merge all binaries into
 - [ ] Code Written
 - [ ] Tests Passed
 - [ ] Documentation Written
+
+## 🎟️ Ticket T5.7: WiFi Credentials Save & Restart
+
+**Milestone**: Web-Based Pro Console
+**Created by**: assistant
+**Status**: 🚧 In Progress
+**Priority**: Medium
+
+### 🎯 Description
+Allow entering Wi-Fi credentials from the web console with an "Extend Network" option. Display SSID/password fields only when enabled and provide a restart button. On restart the firmware should attempt to join the configured AP a few times before falling back to AP mode.
+
+### ✅ Checklist
+- [x] Started
+- [ ] Tests Written
+- [x] Code Written
+- [x] Tests Passed
+- [ ] Documentation Written

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,7 +29,11 @@ void setup() {
     Serial.begin(115200);
     settings_mgr.begin();
     settings_mgr.load(settings);
-    if (!wifi_mgr.connect(settings)) {
+    bool connected = false;
+    if (settings.extend_network) {
+        connected = wifi_mgr.connect(settings, 5);
+    }
+    if (!connected) {
         wifi_mgr.start_ap();
     }
     scene_mgr.begin();

--- a/src/settings_manager.cpp
+++ b/src/settings_manager.cpp
@@ -11,6 +11,7 @@ void SettingsManager::load(ControllerSettings &settings) {
     settings.dmx_universe = prefs.getUShort("dmx_universe", settings.dmx_universe);
     settings.mode = prefs.getUChar("mode", settings.mode);
     settings.is_root = prefs.getBool("is_root", settings.is_root);
+    settings.extend_network = prefs.getBool("extend_network", settings.extend_network);
     settings.ssid = prefs.getString("ssid", settings.ssid);
     settings.password = prefs.getString("password", settings.password);
 }
@@ -22,6 +23,7 @@ void SettingsManager::save(const ControllerSettings &settings) {
     prefs.putUShort("dmx_universe", settings.dmx_universe);
     prefs.putUChar("mode", settings.mode);
     prefs.putBool("is_root", settings.is_root);
+    prefs.putBool("extend_network", settings.extend_network);
     prefs.putString("ssid", settings.ssid);
     prefs.putString("password", settings.password);
 }
@@ -34,6 +36,7 @@ String SettingsManager::to_json(const ControllerSettings &settings) {
     doc["dmx_universe"] = settings.dmx_universe;
     doc["mode"] = settings.mode;
     doc["is_root"] = settings.is_root;
+    doc["extend_network"] = settings.extend_network;
     doc["ssid"] = settings.ssid;
     doc["password"] = settings.password;
     String output;
@@ -53,6 +56,7 @@ void SettingsManager::from_json(const String &json, ControllerSettings &settings
     if (doc.containsKey("dmx_universe")) settings.dmx_universe = doc["dmx_universe"].as<uint16_t>();
     if (doc.containsKey("mode")) settings.mode = doc["mode"].as<uint8_t>();
     if (doc.containsKey("is_root")) settings.is_root = doc["is_root"].as<bool>();
+    if (doc.containsKey("extend_network")) settings.extend_network = doc["extend_network"].as<bool>();
     if (doc.containsKey("ssid")) settings.ssid = doc["ssid"].as<String>();
     if (doc.containsKey("password")) settings.password = doc["password"].as<String>();
 }

--- a/src/settings_manager.h
+++ b/src/settings_manager.h
@@ -11,6 +11,7 @@ struct ControllerSettings {
     uint16_t dmx_universe = 1;
     uint8_t mode = 0;
     bool is_root = false;
+    bool extend_network = false;
     String ssid = "";
     String password = "";
 };

--- a/src/web_server.cpp
+++ b/src/web_server.cpp
@@ -93,6 +93,12 @@ void WebServer::begin(SettingsManager &settings_mgr, ControllerSettings &setting
             req->send(200, "application/json", "{}");
         });
 
+    server.on("/restart", HTTP_POST, [](AsyncWebServerRequest *req) {
+        req->send(200, "text/plain", "restarting");
+        delay(100);
+        ESP.restart();
+    });
+
     if (spiffs_ok && SPIFFS.exists("/index.html")) {
         server.serveStatic("/", SPIFFS, "/").setDefaultFile("index.html");
     } else {

--- a/src/wifi_manager.cpp
+++ b/src/wifi_manager.cpp
@@ -1,16 +1,23 @@
 #include "wifi_manager.h"
 
-bool WiFiManager::connect(ControllerSettings &settings) {
-    if (settings.ssid.isEmpty()) {
+bool WiFiManager::connect(ControllerSettings &settings, uint8_t attempts) {
+    if (!settings.extend_network || settings.ssid.isEmpty()) {
         return false;
     }
     WiFi.mode(WIFI_STA);
-    WiFi.begin(settings.ssid.c_str(), settings.password.c_str());
-    unsigned long start = millis();
-    while (WiFi.status() != WL_CONNECTED && millis() - start < 10000) {
-        delay(500);
+    for (uint8_t i = 0; i < attempts; ++i) {
+        WiFi.begin(settings.ssid.c_str(), settings.password.c_str());
+        unsigned long start = millis();
+        while (WiFi.status() != WL_CONNECTED && millis() - start < 10000) {
+            delay(500);
+        }
+        if (WiFi.status() == WL_CONNECTED) {
+            return true;
+        }
+        WiFi.disconnect(true);
+        delay(1000);
     }
-    return WiFi.status() == WL_CONNECTED;
+    return false;
 }
 
 void WiFiManager::start_ap() {

--- a/src/wifi_manager.h
+++ b/src/wifi_manager.h
@@ -6,7 +6,7 @@
 
 class WiFiManager {
 public:
-    bool connect(ControllerSettings &settings);
+    bool connect(ControllerSettings &settings, uint8_t attempts = 3);
     void start_ap();
 };
 


### PR DESCRIPTION
## Summary
- add `extend_network` option to settings
- try STA connection only when `extend_network` is enabled, otherwise start AP
- expose `/restart` endpoint and restart from web UI
- display Extend Network checkbox with SSID/password fields and restart button
- update TypeScript/JS logic for saving settings and restarting
- document new feature in tickets

## Testing
- `platformio run`
- `npx tsc data/app.ts --outFile data/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68753546dd508332aa381a15f5ab6d2a